### PR TITLE
Align config env variable names and cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Environment Variables
 
 # OpenAI Configuration
-OPENAI_KEY=
+OPENAI_API_KEY=
 
 # Neo4j Configuration for Application Config
 URI_NEO4J=neo4j://neo4j:7687

--- a/docs/LLM_CODEBASE.md
+++ b/docs/LLM_CODEBASE.md
@@ -9,7 +9,7 @@ This document describes the modules under `persona/llm` that implement the integ
 - Returns 1536 dimensional vectors used for Neo4j's vector index.
 
 ```python
-openai_client = openai.Client(api_key=config.MACHINE_LEARNING.OPENAI_KEY)
+openai_client = openai.Client(api_key=config.MACHINE_LEARNING.OPENAI_API_KEY)
 
 def generate_embeddings(texts, model="text-embedding-3-small"):
     response = openai_client.embeddings.create(input=texts, model=model, dimensions=1536)
@@ -25,7 +25,7 @@ def generate_embeddings(texts, model="text-embedding-3-small"):
 - Defines `Node` and `Relationship` schema objects and functions that drive graph construction and querying.
 
 ```python
-openai_client = openai.AsyncOpenAI(api_key=config.MACHINE_LEARNING.OPENAI_KEY)
+openai_client = openai.AsyncOpenAI(api_key=config.MACHINE_LEARNING.OPENAI_API_KEY)
 client = instructor.from_openai(openai_client)
 
 class Node(OpenAISchema):
@@ -49,7 +49,7 @@ response = await client.chat.completions.create(
 
 ## Configuration
 
-The OpenAI API key is loaded from the environment via `server.config`. Ensure `OPENAI_KEY` is defined in `.env` before running the application.
+The OpenAI API key is loaded from the environment via `server.config`. Ensure `OPENAI_API_KEY` is defined in `.env` before running the application.
 
 ## Summary
 

--- a/persona/llm/embeddings.py
+++ b/persona/llm/embeddings.py
@@ -3,8 +3,8 @@ from typing import List, Dict, Any
 import json
 from server.config import config
 
-# openai.api_key = config.MACHINE_LEARNING.OPENAI_KEY
-openai_client = openai.Client(api_key=config.MACHINE_LEARNING.OPENAI_KEY)
+# openai.api_key = config.MACHINE_LEARNING.OPENAI_API_KEY
+openai_client = openai.Client(api_key=config.MACHINE_LEARNING.OPENAI_API_KEY)
 
 def generate_embeddings(texts, model="text-embedding-3-small"):
     try:

--- a/persona/llm/llm_graph.py
+++ b/persona/llm/llm_graph.py
@@ -10,7 +10,7 @@ from pydantic import Field
 from persona.utils.instructions_reader import INSTRUCTIONS
 
 # Initialize the OpenAI client globally if not already set up elsewhere in your application
-openai_client = openai.AsyncOpenAI(api_key=config.MACHINE_LEARNING.OPENAI_KEY)
+openai_client = openai.AsyncOpenAI(api_key=config.MACHINE_LEARNING.OPENAI_API_KEY)
 client = instructor.from_openai(openai_client)
 
 class Node(OpenAISchema):

--- a/server/config.py
+++ b/server/config.py
@@ -9,9 +9,9 @@ load_dotenv()
 
 class Info(BaseModel):
     """Information about the API"""
-    title: str = Field("Innernet API", description="API title")
-    description: str = Field("Backend API for Innernet", description="API description")
-    version: str = Field("0.1.0", description="API version")
+    title: str = Field("Persona API", description="API title")
+    description: str = Field("Backend API for Persona", description="API description")
+    version: str = Field("1.0.0", description="API version")
     root_path: str = Field("/", description="API root path")
     docs_url: Optional[str] = Field("/docs", description="API documentation URL")
     redoc_url: Optional[str] = Field("/redoc", description="ReDoc documentation URL")
@@ -20,23 +20,6 @@ class Info(BaseModel):
         description="Swagger UI parameters"
     )
 
-class Database(BaseModel):
-    """Database configuration"""
-    HOSTNAME: str = Field(environ.get("DB_HOST", "graph-db"), description="Database hostname")
-    PORT: int = Field(environ.get("DB_PORT", 5432), description="Database port")
-    USER: str = Field(environ.get("DB_USER", "postgres"), description="Database username")
-    PASSWORD: str = Field(environ.get("DB_PASSWORD", "postgres"), description="Database password")
-    NAME: str = Field(environ.get("DB_NAME", "color"), description="Database name")
-
-    @property
-    def URI(self) -> str:
-        """Database URI for asyncpg."""
-        return f"postgresql+asyncpg://{self.USER}:{self.PASSWORD}@{self.HOSTNAME}:{self.PORT}/{self.NAME}"
-
-    @property
-    def URI_LLM(self) -> str:
-        """Database URI for LLM"""
-        return f"postgresql://{self.USER}:{self.PASSWORD}@{self.HOSTNAME}:{self.PORT}/{self.NAME}"
 
 class Neo4j(BaseModel):
     """Neo4j configuration"""
@@ -46,23 +29,11 @@ class Neo4j(BaseModel):
 
 class ML(BaseModel):
     """Machine Learning configuration"""
-    URI: str = Field(environ.get("ML_URI", "http://color-ml-local:8080"), description="ML service URI")
-    KW_EXTRACTION_MODEL_NAME: str = Field(
-        environ.get("ML_KW_EXTRACTION_MODEL_NAME", "keybert"),
-        description="Keyword extraction model name"
-    )
-    EMBEDDING_MODEL_NAME: str = Field(
-        environ.get("ML_EMBEDDING_MODEL_NAME", "miniml"),
-        description="Embedding model name"
-    )
-    OPENAI_KEY: str = Field(environ.get("OPENAI_KEY", ""), description="OpenAI API key")
-    OPENAI_ORG: str = Field(environ.get("OPENAI_ORG", ""), description="OpenAI organization")
-    OPENAI_TEXT_COMPLETION_MODEL: str = Field("gpt-3.5-turbo", description="OpenAI text completion model")
+    OPENAI_API_KEY: str = Field(environ.get("OPENAI_API_KEY", ""), description="OpenAI API key")
 
 class BaseConfig(BaseSettings):
     """Base configuration for the application"""
     INFO: Info = Info()
-    DB: Database = Database()
     NEO4J: Neo4j = Neo4j()
     MACHINE_LEARNING: ML = ML()
 


### PR DESCRIPTION
## Summary
- update default API metadata for Persona
- remove unused Postgres and ML settings from config
- load OpenAI key from `OPENAI_API_KEY`
- update docs and examples for new env variable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6853d61c7c4c83249c54ab7644b6f39a